### PR TITLE
Added vwap support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ Supported statistics/indicators are:
 - TRIX: Triple Exponential Moving Average
 - TEMA: Another Triple Exponential Moving Average
 - VR: Volatility Volume Ratio
+- VWAP: Volume Weighted Average Price
 
 Installation
 ------------
@@ -224,6 +225,8 @@ Tutorial
     stock['vr']
     # MAVR is the simple moving average of VR
     stock['vr_6_sma']
+    #vwap is volume weighted average price
+    stock['vwap']
 
 
 - Following options are available for tuning.  Note that all of them are class level options and MUST be changed before any calculation happens.

--- a/README.rst
+++ b/README.rst
@@ -226,7 +226,7 @@ Tutorial
     # MAVR is the simple moving average of VR
     stock['vr_6_sma']
     
-    #vwap is volume weighted average price
+    # VWAP is volume weighted average price
     stock['vwap']
 
 

--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,7 @@ Tutorial
     stock['vr']
     # MAVR is the simple moving average of VR
     stock['vr_6_sma']
+    
     #vwap is volume weighted average price
     stock['vwap']
 

--- a/stockstats.py
+++ b/stockstats.py
@@ -849,6 +849,15 @@ class StockDataFrame(pd.DataFrame):
         cls._drop_columns(df, [ema_short, ema_long, ema_signal])
 
     @classmethod
+    def _get_vwap(cls,df):
+        df['avg_price'] = (df['high']+df['close']+df['low'])/3
+        df['cumilative_volume'] = df['volume'].cumsum()
+        df['pv'] = df['avg_price']*df['volume']
+        df['cumilative_pv'] = df['pv'].cumsum()
+        df['vwap'] = df['cumilative_pv']/df['cumilative_volume']
+        cls._drop_columns(df, ['avg_price', 'cumilative_volume', 'pv', 'cumilative_pv'])
+
+    @classmethod
     def get_only_one_positive_int(cls, windows):
         if isinstance(windows, int):
             window = windows
@@ -990,6 +999,8 @@ class StockDataFrame(pd.DataFrame):
             cls._get_dma(df)
         elif key == 'log-ret':
             cls._get_log_ret(df)
+        elif key in ['vwap']:
+            cls._get_vwap(df)
         elif key.endswith('_delta'):
             cls._get_delta(df, key)
         elif cls.is_cross_columns(key):

--- a/stockstats.py
+++ b/stockstats.py
@@ -855,7 +855,8 @@ class StockDataFrame(pd.DataFrame):
         df['pv'] = df['avg_price']*df['volume']
         df['cumilative_pv'] = df['pv'].cumsum()
         df['vwap'] = df['cumilative_pv']/df['cumilative_volume']
-        cls._drop_columns(df, ['avg_price', 'cumilative_volume', 'pv', 'cumilative_pv'])
+        cls._drop_columns(
+            df, ['avg_price', 'cumilative_volume', 'pv', 'cumilative_pv'])
 
     @classmethod
     def get_only_one_positive_int(cls, windows):


### PR DESCRIPTION
I have added Volume Weighted Average Price indicator support 

my knowledge of vwap is based on [](https://www.investopedia.com/terms/v/vwap.asp#:~:text=VWAP%20is%20calculated%20by%20adding,by%20the%20total%20shares%20traded.)

code sample:-
`stocks = StockDataFrame.retype(df)`
`print(stocks['vwap'].tail(10))`

gives output:- 
Datetime
2020-12-09 12:15:00+05:30    935.595807
2020-12-09 12:20:00+05:30    935.566596
2020-12-09 12:25:00+05:30    935.548274
2020-12-09 12:30:00+05:30    935.543816
2020-12-09 12:35:00+05:30    935.539725
2020-12-09 12:40:00+05:30    935.529548
2020-12-09 12:45:00+05:30    935.516953
2020-12-09 12:50:00+05:30    935.502845
2020-12-09 12:55:00+05:30    935.490450
2020-12-09 12:59:09+05:30    935.490450
Name: vwap, dtype: float64