### PR TITLE
Add Kaufman Adaptive Moving Average

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ Supported statistics/indicators are:
 - TRIX: Triple Exponential Moving Average
 - TEMA: Another Triple Exponential Moving Average
 - VR: Volatility Volume Ratio
+- MFI: Money Flow Index
 
 Installation
 ------------
@@ -211,13 +212,13 @@ Tutorial
 
     # TRIX, default to 12 days
     stock['trix']
-	# TRIX based on the close price for a window of 3
+    # TRIX based on the close price for a window of 3
     stock['close_3_trix']
     # MATRIX is the simple moving average of TRIX
     stock['trix_9_sma']
     # TEMA, another implementation for triple ema
     stock['tema']
-	# TEMA based on the close price for a window of 2
+    # TEMA based on the close price for a window of 2
     stock['close_2_tema']
 
     # VR, default to 26 days
@@ -225,6 +226,8 @@ Tutorial
     # MAVR is the simple moving average of VR
     stock['vr_6_sma']
 
+    # Money flow index, default to 14 days
+    stock['mfi']
 
 - Following options are available for tuning.  Note that all of them are class level options and MUST be changed before any calculation happens.
     - KDJ
@@ -251,6 +254,8 @@ Tutorial
         - TEMA_EMA_WINDOW: default to 5
     - ATR
         - ATR_SMMA: default to 14
+    - MFI
+        - MFI: default to 14
 
 
 To file issue, please visit:

--- a/stockstats.py
+++ b/stockstats.py
@@ -925,7 +925,9 @@ class StockDataFrame(pd.DataFrame):
     @classmethod
     def _get_kama(cls, df, column, windows, fasts=5, slows=34):
         """ get Kaufman's Adaptive Moving Average.
-        Implemented after https://school.stockcharts.com/doku.php?id=technical_indicators:kaufman_s_adaptive_moving_average
+        Implemented after
+        'https://school.stockcharts.com/doku.php?id=technical_
+         indicators:kaufman_s_adaptive_moving_average'
 
         :param df: data
         :param column: column to calculate
@@ -951,8 +953,9 @@ class StockDataFrame(pd.DataFrame):
             df[column_name] = 0.
             for i in range(window, df.shape[0]):
                 last_kama = df.loc[df.index[i-1], column_name]
-                summand = smoothing_constant.iloc[i] \
-                          * (df.loc[df.index[i], column] - last_kama)
+                summand = smoothing_constant.iloc[i] * (df.loc[df.index[i],
+                                                               column]
+                                                        - last_kama)
                 df.loc[df.index[i], column_name] = last_kama + summand
             df.loc[efficiency_ratio.isnull(), column_name] = np.nan
         else:
@@ -1092,7 +1095,8 @@ class StockDataFrame(pd.DataFrame):
                 getattr(cls, func_name)(df, r)
             else:
                 raise UserWarning("Invalid number of return arguments "
-                                  "after parsing column name: '{}'".format(key))
+                                  "after parsing column name: '{}'"
+                                  .format(key))
 
     @staticmethod
     def __init_column(df, key):

--- a/stockstats.py
+++ b/stockstats.py
@@ -909,7 +909,7 @@ class StockDataFrame(pd.DataFrame):
             raw_money_flow = (typical_price * df["volume"]).fillna(0.0)
             higher_rows = ((typical_price - typical_price.shift(1)) >= 0.0).to_numpy()
             lower_rows = ((typical_price - typical_price.shift(1)) < 0.0).to_numpy()
-            for irow, row in enumerate(df.index[n + 1 :]):
+            for irow, row in enumerate(df.index[n - 1 :]):
                 p_pos_money_flow = raw_money_flow.reindex(df.index[irow : irow + n][higher_rows[irow : irow + n]]).sum()
                 p_neg_money_flow = raw_money_flow.reindex(df.index[irow : irow + n][lower_rows[irow : irow + n]]).sum()
                 money_flow_ratio = p_pos_money_flow / (p_neg_money_flow + 1e-12)

--- a/stockstats.py
+++ b/stockstats.py
@@ -923,7 +923,7 @@ class StockDataFrame(pd.DataFrame):
                 df.loc[row, column_name] = 1.0 - 1.0 / (1 + money_flow_ratio)
 
     @classmethod
-    def _get_kama(cls, df, column, windows, fasts: int = 5, slows: int = 34):
+    def _get_kama(cls, df, column, windows, fasts=5, slows=34):
         """ get Kaufman's Adaptive Moving Average.
         Implemented after https://school.stockcharts.com/doku.php?id=technical_indicators:kaufman_s_adaptive_moving_average
 
@@ -1072,7 +1072,6 @@ class StockDataFrame(pd.DataFrame):
                 c, r, t, s, f = ret
                 func_name = '_get_{}'.format(t)
                 getattr(cls, func_name)(df, c, r, s, f)
-                return
             elif len(ret) == 3:
                 c, r, t = ret
                 if t in cls.OPERATORS:

--- a/stockstats.py
+++ b/stockstats.py
@@ -964,7 +964,7 @@ class StockDataFrame(pd.DataFrame):
     @staticmethod
     def parse_column_name(name):
         m = re.match(r'(.*)_([\d\-+~,.]+)_(\w+)', name)
-        ret = (None, None, None)
+        ret = (None,)
         if m is None:
             m = re.match(r'(.*)_([\d\-+~,]+)', name)
             if m is not None:

--- a/stockstats.py
+++ b/stockstats.py
@@ -73,6 +73,9 @@ class StockDataFrame(pd.DataFrame):
 
     MFI = 14
 
+    KAMA_SLOW = 34
+    KAMA_FAST = 5
+
     MULTI_SPLIT_INDICATORS = ("kama",)
 
     # End of options
@@ -923,7 +926,7 @@ class StockDataFrame(pd.DataFrame):
                 df.loc[row, column_name] = 1.0 - 1.0 / (1 + money_flow_ratio)
 
     @classmethod
-    def _get_kama(cls, df, column, windows, fasts=5, slows=34):
+    def _get_kama(cls, df, column, windows, fasts=None, slows=None):
         """ get Kaufman's Adaptive Moving Average.
         Implemented after
         'https://school.stockcharts.com/doku.php?id=technical_
@@ -937,9 +940,13 @@ class StockDataFrame(pd.DataFrame):
         :return: None
         """
         window = cls.get_only_one_positive_int(windows)
-        slow = cls.get_only_one_positive_int(slows)
-        fast = cls.get_only_one_positive_int(fasts)
-        column_name = '{}_{}_kama_{}_{}'.format(column, window, fast, slow)
+        if slows is None or fasts is None:
+            slow, fast = cls.KAMA_SLOW, cls.KAMA_FAST
+            column_name = "{}_{}_kama".format(column, window)
+        else:
+            slow = cls.get_only_one_positive_int(slows)
+            fast = cls.get_only_one_positive_int(fasts)
+            column_name = '{}_{}_kama_{}_{}'.format(column, window, fast, slow)
         if len(df[column]) > window:
             change = abs(df[column] - df[column].shift(window))
             volatility = abs(df[column] - df[column].shift(1)).\

--- a/stockstats.py
+++ b/stockstats.py
@@ -1067,7 +1067,6 @@ class StockDataFrame(pd.DataFrame):
         elif key == 'mfi':
             cls._get_mfi(df)
         else:
-            # possible return variables: c, r, t, s, f
             ret = cls.parse_column_name(key)
             if len(ret) == 5:
                 c, r, t, s, f = ret
@@ -1087,7 +1086,8 @@ class StockDataFrame(pd.DataFrame):
                 func_name = '_get_{}'.format(c)
                 getattr(cls, func_name)(df, r)
             else:
-                raise UserWarning("Invalid number of return arguments after parsing column name: '{}'".format(key))
+                raise UserWarning("Invalid number of return arguments "
+                                  "after parsing column name: '{}'".format(key))
 
     @staticmethod
     def __init_column(df, key):

--- a/test.py
+++ b/test.py
@@ -564,10 +564,10 @@ class StockDataFrameTest(TestCase):
         assert_that(mfi_15.loc[20000509.0], close_to(0.4636, 0.001))
 
     def test_column_kama(self):
-        stock = Sdf.retype(pd.DataFrame(columns=["close"],
-                                        data=[107.92, 107.95, 107.70, 107.97, 106.09, 106.03, 107.65,
-                                              109.54, 110.26, 110.38, 111.94, 113.49, 113.98, 113.91,
-                                              112.62, 112.2, 111.1, 110.18, 111.13, 111.55, 112.08,
-                                              111.95, 111.60, 111.39, 112.25]))
+        kama_ref = [107.92, 107.95, 107.70, 107.97, 106.09, 106.03, 107.65,
+                    109.54, 110.26, 110.38, 111.94, 113.49, 113.98, 113.91,
+                    112.62, 112.2, 111.1, 110.18, 111.13, 111.55, 112.08,
+                    111.95, 111.60, 111.39, 112.25]
+        stock = Sdf.retype(pd.DataFrame(columns=["close"], data=kama_ref))
         kama_10 = stock['close_10_kama_2_30']
         assert_that(kama_10.iloc[-1], close_to(111.631, 0.01))

--- a/test.py
+++ b/test.py
@@ -281,6 +281,13 @@ class StockDataFrameTest(TestCase):
         mvar_3 = stock['open_3_mvar']
         assert_that(mvar_3.loc[20110106], close_to(0.0292, 0.001))
 
+    def test_column_parse_error(self):
+        stock = self.get_stock_90day()
+        with self.assertRaises(UserWarning):
+            _ = stock["foobarbaz"]
+        with self.assertRaises(KeyError):
+            _ = stock["close_1_foo_3_4"]
+
     def test_parse_column_name_1(self):
         c, r, t = Sdf.parse_column_name('amount_-5~-1_p')
         assert_that(c, equal_to('amount'))
@@ -329,10 +336,9 @@ class StockDataFrameTest(TestCase):
         assert_that(r, equal_to('9'))
 
     def test_parse_column_name_no_match(self):
-        c, r, t = Sdf.parse_column_name('no match')
-        assert_that(c, none())
-        assert_that(r, none())
-        assert_that(t, none())
+        ret = Sdf.parse_column_name('no match')
+        assert_that(len(ret), equal_to(1))
+        assert_that(ret[0], none())
 
     def test_to_int_split(self):
         shifts = Sdf.to_ints('5,1,3, -2')

--- a/test.py
+++ b/test.py
@@ -536,11 +536,25 @@ class StockDataFrameTest(TestCase):
         assert_that(c.loc[20160815], close_to(197.52, 0.01))
 
     def test_mfi(self):
-        c_default = self._stock['mfi']
-        assert ((c_default.iloc[:14] == 0.5).all())
-        assert_that(c_default.loc[19991201.0], close_to(0.2675, 0.001))
-        c = self._stock['mfi_15']
-        assert ((c.iloc[:15] == 0.5).all())
-        assert_that(c.loc[19991202.0], close_to(0.2628, 0.001))
-        assert_that(c.loc[20000417.0], close_to(0.5483, 0.001))
-        assert_that(c.loc[20000509.0], close_to(0.4801, 0.001))
+        # test general calculation validity with handmade example
+        from stockstats import StockDataFrame
+        sdf = StockDataFrame(columns=["low", "high", "close", "volume"],
+                             data=[[1.1, 2.1, 1.5, 100],
+                                   [1.15, 2.3, 1.6, 200],
+                                   [1.2, 1.6, 1.9, 150],
+                                   [1.3, 1.8, 1.57, 250],
+                                   [1.44, 2.0, 1.55, 150]])
+        mfi_3_is = sdf["mfi_3"]
+        # was calculated by hand:
+        mfi_3_should = [0.5, 0.5, 0.5889212827988338, 0.3503902862098872, 0.28557802365509344]
+        assert (mfi_3_is - mfi_3_should).abs().max() < 1e-6
+        # regression tests for default settings
+        mfi_default = self._stock['mfi']
+        assert ((mfi_default.iloc[:13] == 0.5).all())
+        assert_that(mfi_default.loc[19991201.0], close_to(0.3597, 0.001))
+        # regression tests for custom settings
+        mfi_15 = self._stock['mfi_15']
+        assert ((mfi_15.iloc[:14] == 0.5).all())
+        assert_that(mfi_15.loc[19991202.0], close_to(0.3532, 0.001))
+        assert_that(mfi_15.loc[20000417.0], close_to(0.47589, 0.001))
+        assert_that(mfi_15.loc[20000509.0], close_to(0.4636, 0.001))

--- a/test.py
+++ b/test.py
@@ -546,7 +546,11 @@ class StockDataFrameTest(TestCase):
                                    [1.44, 2.0, 1.55, 150]])
         mfi_3_is = sdf["mfi_3"]
         # was calculated by hand:
-        mfi_3_should = [0.5, 0.5, 0.5889212827988338, 0.3503902862098872, 0.28557802365509344]
+        mfi_3_should = [0.5,
+                        0.5,
+                        0.5889212827988338,
+                        0.3503902862098872,
+                        0.28557802365509344]
         assert (mfi_3_is - mfi_3_should).abs().max() < 1e-6
         # regression tests for default settings
         mfi_default = self._stock['mfi']

--- a/test.py
+++ b/test.py
@@ -324,7 +324,7 @@ class StockDataFrameTest(TestCase):
         assert_that(t, equal_to('c'))
 
     def test_parse_column_name_rsv(self):
-        c, r, t = Sdf.parse_column_name('rsv_9')
+        c, r = Sdf.parse_column_name('rsv_9')
         assert_that(c, equal_to('rsv'))
         assert_that(r, equal_to('9'))
 
@@ -562,3 +562,12 @@ class StockDataFrameTest(TestCase):
         assert_that(mfi_15.loc[19991202.0], close_to(0.3532, 0.001))
         assert_that(mfi_15.loc[20000417.0], close_to(0.47589, 0.001))
         assert_that(mfi_15.loc[20000509.0], close_to(0.4636, 0.001))
+
+    def test_column_kama(self):
+        stock = Sdf.retype(pd.DataFrame(columns=["close"],
+                                        data=[107.92, 107.95, 107.70, 107.97, 106.09, 106.03, 107.65,
+                                              109.54, 110.26, 110.38, 111.94, 113.49, 113.98, 113.91,
+                                              112.62, 112.2, 111.1, 110.18, 111.13, 111.55, 112.08,
+                                              111.95, 111.60, 111.39, 112.25]))
+        kama_10 = stock['close_10_kama_2_30']
+        assert_that(kama_10.iloc[-1], close_to(111.631, 0.01))

--- a/test.py
+++ b/test.py
@@ -577,3 +577,5 @@ class StockDataFrameTest(TestCase):
         stock = Sdf.retype(pd.DataFrame(columns=["close"], data=kama_ref))
         kama_10 = stock['close_10_kama_2_30']
         assert_that(kama_10.iloc[-1], close_to(111.631, 0.01))
+        kama_2 = stock['close_2_kama']
+        assert_that(kama_2.iloc[-1], close_to(111.907, 0.01))

--- a/test.py
+++ b/test.py
@@ -534,3 +534,13 @@ class StockDataFrameTest(TestCase):
         assert_that(c.loc[20160817], close_to(182.77, 0.01))
         assert_that(c.loc[20160816], close_to(190.1, 0.01))
         assert_that(c.loc[20160815], close_to(197.52, 0.01))
+
+    def test_mfi(self):
+        c_default = self._stock['mfi']
+        assert ((c_default.iloc[:14] == 0.5).all())
+        assert_that(c_default.loc[19991201.0], close_to(0.2675, 0.001))
+        c = self._stock['mfi_15']
+        assert ((c.iloc[:15] == 0.5).all())
+        assert_that(c.loc[19991202.0], close_to(0.2628, 0.001))
+        assert_that(c.loc[20000417.0], close_to(0.5483, 0.001))
+        assert_that(c.loc[20000509.0], close_to(0.4801, 0.001))


### PR DESCRIPTION
The indicator was tested against the reference [investopedia article](https://school.stockcharts.com/doku.php?id=technical_indicators:kaufman_s_adaptive_moving_average). It has more settings than other indicators, so the name could be parsed into five parts now.

_close_10_kama_2_30_

has three settings:

- _10 is the number of periods for the Efficiency Ratio (ER)._
- _2 is the number of periods for the fastest EMA constant._
- _30 is the number of periods for the slowest EMA constant._

To make sure regular indicators are parsed as usual, only those within the tuple MULTI_SPLIT_INDICATORS will be parsed into five parts. 