### PR TITLE
[GH-94] Improve mfi performance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 pandas>=0.24.2
-int_date>=0.1.7


### PR DESCRIPTION
The calculation of the `mfi` indicator takes seconds.

Enhance the algorithm to improve the performance.
Reduce the size of the test to make shorten the duration of the tests.

Remove some dead code.