### PR TITLE
copy should not modify data

### DIFF
--- a/stockstats.py
+++ b/stockstats.py
@@ -31,18 +31,19 @@ import re
 
 import numpy as np
 import pandas as pd
+import copy
 
 __author__ = 'Cedric Zhuang'
 
 
-def wrap(df, index_column=None):
+def wrap(df, index_column=None, lowerCase=True):
     """ wraps a pandas DataFrame to StockDataFrame
 
     :param df: pandas DataFrame
     :param index_column: the name of the index column, default to ``date``
     :return: an object of StockDataFrame
     """
-    return StockDataFrame.retype(df, index_column)
+    return StockDataFrame.retype(df, index_column, lowerCase)
 
 
 def unwrap(sdf):
@@ -1270,7 +1271,7 @@ class StockDataFrame(pd.DataFrame):
         return self.start_from(start_date).till(end_date)
 
     def copy(self, deep=True):
-        return wrap(super(StockDataFrame, self).copy(deep))
+        return wrap(super(StockDataFrame, self).copy(deep), lowerCase=False)
 
     def _ensure_type(self, obj):
         """ override the method in pandas, omit the check
@@ -1280,7 +1281,7 @@ class StockDataFrame(pd.DataFrame):
         return obj
 
     @staticmethod
-    def retype(value, index_column=None):
+    def retype(value, index_column=None, lowerCase=True):
         """ if the input is a `DataFrame`, convert it to this class.
 
         :param index_column: name of the index column, default to `date`
@@ -1290,11 +1291,13 @@ class StockDataFrame(pd.DataFrame):
         if index_column is None:
             index_column = 'date'
 
+        print(type(value))
         if isinstance(value, StockDataFrame):
             return value
         elif isinstance(value, pd.DataFrame):
-            # use all lower case for column name
-            value.columns = map(lambda c: c.lower(), value.columns)
+            if lowerCase:
+                # use all lower case for column name
+                value.columns = map(lambda c: c.lower(), value.columns)
 
             if index_column in value.columns:
                 value.set_index(index_column, inplace=True)

--- a/stockstats.py
+++ b/stockstats.py
@@ -45,11 +45,9 @@ def wrap(df, index_column=None, lowerCase=True):
     """
     return StockDataFrame.retype(df, index_column, lowerCase)
 
-
 def unwrap(sdf):
     """ convert a StockDataFrame back to a pandas DataFrame """
     return pd.DataFrame(sdf)
-
 
 class StockDataFrame(pd.DataFrame):
     # Start of options.
@@ -1248,7 +1246,7 @@ class StockDataFrame(pd.DataFrame):
 
     def __getitem__(self, item):
         try:
-            result = wrap(super(StockDataFrame, self).__getitem__(item))
+            result = wrap(super(StockDataFrame, self).__getitem__(item), lowerCase=False)
         except KeyError:
             try:
                 if isinstance(item, list):
@@ -1258,7 +1256,7 @@ class StockDataFrame(pd.DataFrame):
                     self.__init_column(item)
             except AttributeError:
                 pass
-            result = wrap(super(StockDataFrame, self).__getitem__(item))
+            result = wrap(super(StockDataFrame, self).__getitem__(item), lowerCase=False)
         return result
 
     def till(self, end_date):

--- a/stockstats.py
+++ b/stockstats.py
@@ -1291,7 +1291,6 @@ class StockDataFrame(pd.DataFrame):
         if index_column is None:
             index_column = 'date'
 
-        print(type(value))
         if isinstance(value, StockDataFrame):
             return value
         elif isinstance(value, pd.DataFrame):


### PR DESCRIPTION
Hi there, 

thanks for your wonderful lib, really like it. 

When using your lib together with other frameworks I run into the problem that a copy call in the other framework caused the column names to be renamed to lower case, which the other framework can't handle. I scanned your code and found that the copy function has this "feature" in it. 

As I think a copy should not modify the data compared to the original one I introduced a lowerCase-Flag in wrap and retype causing copy to leave the column names as they are. With that modification I was able to run your StockDataFrame also with other frameworks like backtesting.py 

Best regards, 
Neutro2