### PR TITLE
Fix issue 125 - Supertrend misscalculation

### DIFF
--- a/stockstats.py
+++ b/stockstats.py
@@ -586,12 +586,12 @@ class StockDataFrame(pd.DataFrame):
 
             # calculate supertrend
             if last_st == last_ub:
-                if curr_close <= ub[i]:
+                if curr_close <= last_ub:
                     st[i] = ub[i]
                 else:
                     st[i] = lb[i]
             elif last_st == last_lb:
-                if curr_close > lb[i]:
+                if curr_close > last_lb:
                     st[i] = lb[i]
                 else:
                     st[i] = ub[i]


### PR DESCRIPTION
Adjusting supertrend evaluation by comparing previous close value instead of current

Link to [the issue](https://github.com/jealous/stockstats/issues/125) (I am unable to link them direcly over github).