### PR TITLE
[GH-122] Update calculation of `middle`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "2.7", "3.9", "3.10" ]
+        python-version: [ "2.7", "3.10", "3.11" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -32,7 +32,7 @@ jobs:
         run: |
           py.test --cov=stockstats test.py
       - name: Publish Test Results
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ matrix.python-version == '3.11' }}
         run: codecov
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/jealous/stockstats/branch/master/graph/badge.svg?token=IFMD1pVJ7T)](https://codecov.io/gh/jealous/stockstats)
 [![pypi](https://img.shields.io/pypi/v/stockstats.svg)](https://pypi.python.org/pypi/stockstats)
 
-VERSION: 0.4.1
+VERSION: 0.5.0
 
 ## Introduction
 
@@ -263,7 +263,7 @@ In [22]: tp = df['middle']
                                                        
 In [23]: df['res'] = df['middle'] > df['close']        
                                                        
-In [24]: df[['middle', 'close', 'res', 'res_-10_c']]    
+In [24]: df[['middle', 'close', 'res', 'res_10_c']]    
 Out[24]:                                               
              middle  close    res  res_10_c            
 date                                                   
@@ -502,7 +502,7 @@ resistance levels.
 It includes three lines:
 * `df['kdjk']` - K series
 * `df['kdjd']` - D series
-* `df['kdfj']` - J series
+* `df['kdjj']` - J series
 
 The default window is 9.  Use `StockDataFrame.KDJ_WINDOW` to change it.
 Use `df['kdjk_6']` to retrieve the K series of 6 periods.
@@ -527,6 +527,9 @@ It contains 4 lines:
 
 It's the average of `high`, `low` and `close`.
 Use `df['middle']` to access this value.
+
+When `amount` is available, `middle = amount / volume`
+This should be more accurate because amount represents the total cash flow. 
 
 #### [Bollinger Bands](https://en.wikipedia.org/wiki/Bollinger_Bands)
 


### PR DESCRIPTION
The typical price or middle price is calculated by:
```
(high + low + close) / 3
```

But it would be accurate if the data source has the `amount` that represents the total amount of capital traded in that period. Use `middle = amount / volume` when amout is available.

Also fix some typos in the read me file.
Add some utilities for dropping columns, head or tail.

Add python 3.11 in CI and drop 3.9.