### PR TITLE
[GH-116] Add ichimoku cloud width

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Supported statistics/indicators are:
 * MAD: Mean Absolute Deviation
 * ROC: Rate of Change
 * Coppock: Coppock Curve
+* Ichimoku: Ichimoku Cloud
 
 ## Installation
 
@@ -805,6 +806,36 @@ Examples:
 * `df['coppock']` returns the Coppock Curve with default windows
 * `df['coppock_5,10,15']` returns the Coppock Curve with WMA window 5,
   fast window 10, slow window 15. 
+
+#### [Ichimoku Cloud](https://www.investopedia.com/terms/i/ichimoku-cloud.asp)
+
+The Ichimoku Cloud is a collection of technical indicators
+that show support and resistance levels, as well as momentum
+and trend direction.
+
+In this implementation, we only calculate the delta between
+lead A and lead B (which is the width of the cloud).
+
+It contains three windows:
+* window for the conversion line, default to 9
+* window for the baseline and the shifts, default to 26
+* window for the leading line, default to 52
+
+Formular:
+* conversion line = (PH9 + PL9) / 2
+* baseline = (PH26 + PL26) / 2
+* leading span A = (conversion line + baseline) / 2
+* leading span B = (PH52 + PL52) / 2
+* result = leading span A - leading span B
+
+Where:
+* PH = Period High
+* PL = Period Low
+
+Examples:
+* `df['ichimoku']` returns the ichimoku cloud width with default windows
+* `df['ichimoku_7,22,44']` returns the ichimoku cloud width with window sizes
+  7, 22, 44
 
 ## Issues
 

--- a/test.py
+++ b/test.py
@@ -798,6 +798,23 @@ class StockDataFrameTest(TestCase):
         res = StockDataFrame._mad(series, 6)
         assert_that(res[5], near_to(2.667))
 
+    def test_ichimoku(self):
+        stock = self.get_stock_90days()
+        i0 = stock['ichimoku']
+        i1 = stock['ichimoku_9,26,52']
+        i2 = stock['ichimoku_5,10,20']
+        assert_that(i0[20110228], equal_to(0))
+        assert_that(i0[20110308], near_to(0.0275))
+        assert_that(i0[20110318], near_to(-0.0975))
+
+        assert_that(i1[20110228], equal_to(0))
+        assert_that(i1[20110308], near_to(0.0275))
+        assert_that(i1[20110318], near_to(-0.0975))
+
+        assert_that(i2[20110228], near_to(-0.11))
+        assert_that(i2[20110308], near_to(0.0575))
+        assert_that(i2[20110318], near_to(0.0175))
+
     @staticmethod
     def test_linear_wma():
         series = pd.Series([10, 15, 15, 17, 18, 21])


### PR DESCRIPTION
The Ichimoku Cloud is a collection of technical indicators that show support and resistance levels, as well as momentum and trend direction.

In this implementation, we only calculate the delta between lead A and lead B (which is the width of the cloud).

It contains three windows:
* window for the conversion line, default to 9
* window for the baseline and the shifts, default to 26
* window for the leading line, default to 52

Formular:
* conversion line = (PH9 + PL9) / 2
* baseline = (PH26 + PL26) / 2
* leading span A = (conversion line + baseline) / 2
* leading span B = (PH52 + PL52) / 2
* result = leading span A - leading span B

Where:
* PH = Period High
* PL = Period Low

Examples:
* `df['ichimoku']` returns the ichimoku cloud width with default windows
* `df['ichimoku_7,22,44']` returns the ichimoku cloud width with window sizes 7, 22, 44