### PR TITLE
[GH-154] Add Elder-Ray Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Supported statistics/indicators are:
 * Ichimoku: Ichimoku Cloud
 * CTI: Correlation Trend Indicator
 * LRMA: Linear Regression Moving Average
+* ERI: Elder-Ray Index
 
 ## Installation
 
@@ -670,6 +671,23 @@ Examples:
 * `df['mfi']` retrieves the 14 periods MFI
 * `df['mfi_6']` retrieves the 6 periods MFI
 
+#### [ERI - Elder-Ray Index](https://admiralmarkets.com/education/articles/forex-indicators/bears-and-bulls-power-indicator)
+
+The Elder-Ray Index contains the bull and the bear power.
+Both are calculated based on the EMA of the close price.
+
+The default window is 13.
+
+Formular:
+* Bulls Power = High - EMA
+* Bears Power = Low - EMA
+* EMA is exponential moving average of close of N periods
+
+Examples:
+* `df['eribull']` retrieves the 13 periods bull power
+* `df['eribear']` retrieves the 13 periods bear power
+* `df['eribull_5']` retrieves the 5 periods bull power
+* `df['eribear_5']` retrieves the 5 periods bear power
 
 #### [KER - Kaufman's efficiency ratio](https://strategyquant.com/codebase/kaufmans-efficiency-ratio-ker/)
 

--- a/test.py
+++ b/test.py
@@ -309,6 +309,27 @@ class StockDataFrameTest(TestCase):
         assert_that(stock['ppos'].loc[20110331], near_to(0.6840))
         assert_that(stock['ppoh'].loc[20110331], near_to(0.4349))
 
+    def test_eri(self):
+        stock = self.get_stock_90days()
+        bull = stock['eribull']
+        bear = stock['eribear']
+        assert_that(bull[20110104], near_to(0.070))
+        assert_that(bear[20110104], near_to(-0.309))
+        assert_that(bull[20110222], near_to(0.099))
+        assert_that(bear[20110222], near_to(-0.290))
+
+        bull = stock['eribull_13']
+        bear = stock['eribear_13']
+        assert_that(bull[20110104], near_to(0.070))
+        assert_that(bear[20110104], near_to(-0.309))
+        assert_that(bull[20110222], near_to(0.099))
+        assert_that(bear[20110222], near_to(-0.290))
+
+        bull = stock['eribull_10']
+        bear = stock['eribear_10']
+        assert_that(bull[20110222], near_to(0.092))
+        assert_that(bear[20110222], near_to(-0.297))
+
     def test_column_mstd(self):
         stock = self.get_stock_20days()
         mstd_3 = stock['close_3_mstd']


### PR DESCRIPTION
The Elder-Ray Index contains the bull and the bear power. Both are calculated based on the EMA of the close price.

The default window is 13.

Formular:
* Bulls Power = High - EMA
* Bears Power = Low - EMA
* EMA is exponential moving average of close of N periods

Examples:
* `df['eribull']` retrieves the 13 periods bull power
* `df['eribear']` retrieves the 13 periods bear power
* `df['eribull_5']` retrieves the 5 periods bull power
* `df['eribear_5']` retrieves the 5 periods bear power