### PR TITLE
[GH-160] Add Relative Vigor Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Supported statistics/indicators are:
 * LRMA: Linear Regression Moving Average
 * ERI: Elder-Ray Index
 * FTR: the Gaussian Fisher Transform Price Reversals indicator
+* RVGI: Relative Vigor Index
 
 ## Installation
 
@@ -922,6 +923,42 @@ Formular:
 Examples:
 * `df['ftr']` returns the FTR with window 9
 * `df['ftr_20']` returns the FTR with window 20
+
+#### [Relative Vigor Index (RVGI)](https://www.investopedia.com/terms/r/relative_vigor_index.asp)
+
+The Relative Vigor Index (RVI) is a momentum indicator
+used in technical analysis that measures the strength
+of a trend by comparing a security's closing price to
+its trading range while smoothing the results using a
+simple moving average (SMA).
+
+Formular
+
+* NUMERATOR= (a+(2×b)+(2×c)+d) / 6
+* DENOMINATOR= (e+(2×f)+(2×g)+h) / 6
+* RVI= SMA-N of DENOMINATOR / SMA-N of NUMERATOR
+* Signal Line = (RVI+(2×i)+(2×j)+k) / 6
+
+where:
+
+* a=Close−Open
+* b=Close−Open One Bar Prior to a
+* c=Close−Open One Bar Prior to b
+* d=Close−Open One Bar Prior to c
+* e=High−Low of Bar a
+* f=High−Low of Bar b
+* g=High−Low of Bar c
+* h=High−Low of Bar d
+* i=RVI Value One Bar Prior
+* j=RVI Value One Bar Prior to i
+* k=RVI Value One Bar Prior to j
+* N=Minutes/Hours/Days/Weeks/Months
+
+Examples:
+* `df['rvgi']` retrieves the RVGI line of window 14
+* `df['rvgis']` retrieves the RVGI signal line of window 14
+* `df['rvgi_5']` retrieves the RVGI line of window 5
+* `df['rvgis_5']` retrieves the RVGI signal line of window 5
 
 ## Issues
 

--- a/test.py
+++ b/test.py
@@ -889,6 +889,15 @@ class StockDataFrameTest(TestCase):
         res = StockDataFrame._mad(series, 6)
         assert_that(res[5], near_to(2.667))
 
+    @staticmethod
+    def test_sym_wma4():
+        series = pd.Series([4, 2, 2, 4, 8])
+        res = StockDataFrame.sym_wma4(series)
+        assert_that(res[0], equal_to(0))
+        assert_that(res[2], equal_to(0))
+        assert_that(res[3], near_to(2.666))
+        assert_that(res[4], near_to(3.666))
+
     def test_ichimoku(self):
         stock = self.get_stock_90days()
         i0 = stock['ichimoku']
@@ -976,6 +985,21 @@ class StockDataFrameTest(TestCase):
 
         f = stock['ftr_15']
         assert_that(f[20110128], near_to(-1.005))
+
+    def test_rvgi(self):
+        stock = self.get_stock_30days()
+        r, s = stock['rvgi'], stock['rvgis']
+        r14, s14 = stock['rvgi_14'], stock['rvgis_14']
+        assert_that(r[20110128], equal_to(r14[20110128]))
+        assert_that(s[20110128], equal_to(s14[20110128]))
+        assert_that(r[20110106], equal_to(0))
+        assert_that(r[20110107], near_to(0.257))
+        assert_that(s[20110111], equal_to(0))
+        assert_that(s[20110112], near_to(0.303))
+
+        s10, r10 = stock['rvgis_10'], stock['rvgi_10']
+        assert_that(r10[20110128], near_to(-0.056))
+        assert_that(s10[20110128], near_to(-0.043))
 
     def test_change_group_window_defaults(self):
         stock = self.get_stock_90days()


### PR DESCRIPTION
The Relative Vigor Index (RVI) is a momentum indicator used in technical analysis that measures the strength of a trend by comparing a security's closing price to its trading range while smoothing the results using a simple moving average (SMA).

https://www.investopedia.com/terms/r/relative_vigor_index.asp

Formular

* NUMERATOR= (a+(2×b)+(2×c)+d) / 6
* DENOMINATOR= (e+(2×f)+(2×g)+h) / 6
* RVI= SMA-N of DENOMINATOR / SMA-N of NUMERATOR
* Signal Line = (RVI+(2×i)+(2×j)+k) / 6

where:

* a=Close−Open
* b=Close−Open One Bar Prior to a
* c=Close−Open One Bar Prior to b
* d=Close−Open One Bar Prior to c
* e=High−Low of Bar a
* f=High−Low of Bar b
* g=High−Low of Bar c
* h=High−Low of Bar d
* i=RVI Value One Bar Prior
* j=RVI Value One Bar Prior to i
* k=RVI Value One Bar Prior to j
* N=Minutes/Hours/Days/Weeks/Months

Examples:
* `df['rvgi']` retrieves the RVGI line of window 14
* `df['rvgis']` retrieves the RVGI signal line of window 14
* `df['rvgi_5']` retrieves the RVGI line of window 5
* `df['rvgis_5']` retrieves the RVGI signal line of window 5