### PR TITLE
[GH-171] Add support for PVO

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Supported statistics/indicators are:
 * KST: Know Sure Thing
 * PGO: Pretty Good Oscillator
 * PSL: Psychological Line
+* PVO: Percentage Volume Oscillator
 
 ## Installation
 
@@ -1022,6 +1023,27 @@ Example:
 * `df['psl_10']` retrieves the PSL with window 10.
 * `df['high_12_psl']` retrieves the PSL of high price with window 10.
 
+#### [Percentage Volume Oscillator(PVO)](https://school.stockcharts.com/doku.php?id=technical_indicators:percentage_volume_oscillator_pvo)
+
+The Percentage Volume Oscillator (PVO) is a momentum oscillator for volume. 
+The PVO measures the difference between two volume-based moving averages as
+a percentage of the larger moving average.
+
+Formular: 
+
+* Percentage Volume Oscillator (PVO): 
+  ((12-day EMA of Volume - 26-day EMA of Volume)/26-day EMA of Volume) x 100
+* Signal Line: 9-day EMA of PVO
+* PVO Histogram: PVO - Signal Line
+
+Example:
+* `df['pvo']` derives from the difference of 2 exponential moving average.
+* `df['pvos]` is the signal line.
+* `df['pvoh']` is he histogram line.
+
+The period of short, long EMA and signal line can be tuned with 
+`set_dft_window('pvo', (short, long, signal))`.  The default
+windows are 12 and 26 and 9.
 
 ## Issues
 

--- a/test.py
+++ b/test.py
@@ -1079,3 +1079,10 @@ class StockDataFrameTest(TestCase):
         high_psl12 = stock['high_12_psl']
         assert_that(high_psl12[20110118], near_to(41.666))
         assert_that(high_psl12[20110127], near_to(41.666))
+
+    def test_pvo(self):
+        stock = self.get_stock_90days()
+        _ = stock[['pvo', 'pvos', 'pvoh']]
+        assert_that(stock['pvo'].loc[20110331], near_to(3.4708))
+        assert_that(stock['pvos'].loc[20110331], near_to(-3.7464))
+        assert_that(stock['pvoh'].loc[20110331], near_to(7.2173))


### PR DESCRIPTION
The Percentage Volume Oscillator (PVO) is a momentum oscillator for volume. The PVO measures the difference between two volume-based moving averages as a percentage of the larger moving average.

https://school.stockcharts.com/doku.php?id=technical_indicators:percentage_volume_oscillator_pvo

Formular:

* Percentage Volume Oscillator (PVO): ((12-day EMA of Volume - 26-day EMA of Volume)/26-day EMA of Volume) x 100
* Signal Line: 9-day EMA of PVO
* PVO Histogram: PVO - Signal Line