### PR TITLE
Numerical comparison implemented

### DIFF
--- a/stockstats.py
+++ b/stockstats.py
@@ -1750,7 +1750,8 @@ class StockDataFrame(pd.DataFrame):
         decimal_places = 0.0
         if (len(split) > 1):
             decimal_places_str = split[1]
-            decimal_places = int(decimal_places_str) * pow(0.1, len(decimal_places_str))
+            decimal_places = int(decimal_places_str) *
+                            pow(0.1, len(decimal_places_str))
         self[meta.name] = meta.int0 + decimal_places
 
     def to_series(self, arr: list):

--- a/stockstats.py
+++ b/stockstats.py
@@ -1750,8 +1750,8 @@ class StockDataFrame(pd.DataFrame):
         decimal_places = 0.0
         if (len(split) > 1):
             decimal_places_str = split[1]
-            decimal_places = int(decimal_places_str) *
-                            pow(0.1, len(decimal_places_str))
+            power = pow(0.1, len(decimal_places_str))
+            decimal_places = float(decimal_places_str) * power
         self[meta.name] = meta.int0 + decimal_places
 
     def to_series(self, arr: list):

--- a/stockstats.py
+++ b/stockstats.py
@@ -88,6 +88,7 @@ _dft_windows = {
     'wt': (10, 21),
     'vr': 26,
     'vwma': 14,
+    'num': 0,
 }
 
 
@@ -1744,6 +1745,14 @@ class StockDataFrame(pd.DataFrame):
         self[meta.name_ex('l')] = self.to_series(qqe_long)
         self[meta.name_ex('s')] = self.to_series(qqe_short)
 
+    def _get_num(self, meta):
+        split = meta.name.split(',')
+        decimal_places = 0.0
+        if (len(split) > 1):
+            decimal_places_str = split[1]
+            decimal_places = int(decimal_places_str) * pow(0.1, len(decimal_places_str))
+        self[meta.name] = meta.int0 + decimal_places
+
     def to_series(self, arr: list):
         return pd.Series(arr, index=self.close.index).fillna(0)
 
@@ -1900,6 +1909,7 @@ class StockDataFrame(pd.DataFrame):
             ('eribull', 'eribear'): self._get_eri,
             ('rvgi', 'rvgis'): self._get_rvgi,
             ('kst',): self._get_kst,
+            ('num',): self._get_num,
         }
         for k in _dft_windows.keys():
             if k not in ret:


### PR DESCRIPTION
1st commit implements the compare function itself.

2nd commit implements `_get_num()` for filling in numerical values (e.g. `num_10` for 10.0 and `num_10,01` for 10.01).

Merge it if you wish.

One thing to note, I am getting the following warning:
```
PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`
  self[key] = self[left] < self[right]
```
I am not sure when it started appearing but I don't think it was there before the second commit so it needs further testing. Other than that everything seems to be working properly, I kept my changes minimal.