### PR TITLE
[GH-190] copy slice warn getting multiple cols

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/stockstats.py
+++ b/stockstats.py
@@ -2016,7 +2016,7 @@ class StockDataFrame(pd.DataFrame):
         if isinstance(value, StockDataFrame):
             return value
         elif isinstance(value, pd.DataFrame):
-            value.rename(_lower_col_name, axis='columns', inplace=True)
+            value = value.rename(_lower_col_name, axis='columns')
             if index_column in value.columns:
                 value.set_index(index_column, inplace=True)
             ret = StockDataFrame(value)


### PR DESCRIPTION
Pandas report warning when we retrieve/initialize multiple columns with following syntax:

```python
df[['kdjk', 'kdjj']]
```

Update the call of the `rename` function to use return value instead of inplace change to avoid this warning.