### PR TITLE
[GH-193] Shift an series frame raise error

### DIFF
--- a/stockstats.py
+++ b/stockstats.py
@@ -388,7 +388,9 @@ class StockDataFrame(pd.DataFrame):
         :param window: number of periods to shift
         :return: the shifted series with filled gap
         """
-        ret = series.shift(-window)
+        if series.empty:
+            return series.copy()
+        ret = series.shift(-window).copy()
         if window < 0:
             ret.iloc[:-window] = series.iloc[0]
         elif window > 0:
@@ -426,7 +428,8 @@ class StockDataFrame(pd.DataFrame):
         :return: result series
         """
         shift = meta.int
-        reversed_series = self[meta.column][::-1]
+        series = self[meta.column]
+        reversed_series = series[::-1]
         rolled = self._rolling(reversed_series, shift)
         reversed_counts = rolled.apply(np.count_nonzero, raw=True)
         counts = reversed_counts[::-1]
@@ -2020,7 +2023,6 @@ class StockDataFrame(pd.DataFrame):
             if index_column in value.columns:
                 value.set_index(index_column, inplace=True)
             ret = StockDataFrame(value)
-            # ret.columns.name = name
             return ret
         return value
 

--- a/test.py
+++ b/test.py
@@ -1111,6 +1111,30 @@ class StockDataFrameTest(TestCase):
         assert_that(high_psl12[20110118], near_to(41.666))
         assert_that(high_psl12[20110127], near_to(41.666))
 
+    def test_s_shift(self):
+        stock = self.get_stock_90days()
+        close_n1 = StockDataFrame.s_shift(stock['close'], -1)
+        close_0 = StockDataFrame.s_shift(stock['close'], 0)
+        close_p1 = StockDataFrame.s_shift(stock['close'], 1)
+        assert_that(close_n1[20110104], near_to(12.61))
+        assert_that(close_n1[20110105], near_to(12.61))
+        assert_that(close_n1[20110106], near_to(12.71))
+
+        assert_that(close_0[20110106], near_to(12.67))
+        assert_that(close_0[20110330],  equal_to(13.85))
+
+        assert_that(close_p1[20110329], near_to(13.85))
+        assert_that(close_p1[20110330], near_to(13.62))
+        assert_that(close_p1[20110331], near_to(13.62))
+
+    def test_s_shift_when_df_is_empty(self):
+        stock = self.get_stock_90days()
+        empty_df = stock[:0]
+        close_n1 = StockDataFrame.s_shift(empty_df['close'], -1)
+        close_p1 = StockDataFrame.s_shift(empty_df['close'], 1)
+        assert_that(close_n1, has_length(0))
+        assert_that(close_p1, has_length(0))
+
     def test_pvo(self):
         stock = self.get_stock_90days()
         _ = stock[['pvo', 'pvos', 'pvoh']]


### PR DESCRIPTION
The shift function cannot accept empty series.
The reason is we use previous/next value to fill the empty cell. An empty data frame results in a invalid index error.

The fix returns the empty series.