### PR TITLE
test: add regression tests for KDJ flat candles (#185) and VR neutral days (#115)

### DIFF
--- a/test.py
+++ b/test.py
@@ -355,7 +355,7 @@ class StockDataFrameTest(TestCase):
         data = pd.DataFrame({
             'open': [10.0] * 30,
             'high': [10.5] * 30,
-            'low': [9.5]  * 30,
+            'low': [9.5] * 30,
             'close': [10.0] * 30,   # no change => all neutral days
             'volume': [1000] * 30,
         })

--- a/test.py
+++ b/test.py
@@ -325,10 +325,10 @@ class StockDataFrameTest(TestCase):
         """
         import numpy as np
         data = pd.DataFrame({
-            'open':   [10.0] * 20,
-            'high':   [10.0] * 20,
-            'low':    [10.0] * 20,
-            'close':  [10.0] * 20,
+            'open': [10.0] * 20,
+            'high': [10.0] * 20,
+            'low': [10.0] * 20,
+            'close': [10.0] * 20,
             'volume': [1000] * 20,
         })
         stock = wrap(data)
@@ -353,10 +353,10 @@ class StockDataFrameTest(TestCase):
         """
         import numpy as np
         data = pd.DataFrame({
-            'open':   [10.0] * 30,
-            'high':   [10.5] * 30,
-            'low':    [9.5]  * 30,
-            'close':  [10.0] * 30,   # no change => all neutral days
+            'open': [10.0] * 30,
+            'high': [10.5] * 30,
+            'low': [9.5]  * 30,
+            'close': [10.0] * 30,   # no change => all neutral days
             'volume': [1000] * 30,
         })
         stock = wrap(data)

--- a/test.py
+++ b/test.py
@@ -71,7 +71,7 @@ class YFinanceCompatibilityTest(TestCase):
     _stock = wrap(
         df=yf.download(
             "002032.SZ",
-            auto_adjust=False,  # ← raw prices
+            auto_adjust=False,  # <- raw prices
             actions=True,  # keep dividends & splits separate
             period="max",
         )
@@ -313,6 +313,62 @@ class StockDataFrameTest(TestCase):
         assert_that(row["kdjk"], near_to(66.666))
         assert_that(row["kdjd"], near_to(55.555))
         assert_that(row["kdjj"], near_to(88.888))
+
+    @staticmethod
+    def test_kdj_flat_candles():
+        """Regression test for issue #185.
+
+        When high == low for every bar (perfectly flat candles), the
+        RSV denominator is zero.  _divide() must return 0.0 rather than
+        raising ZeroDivisionError or producing NaN/inf, and the
+        downstream K, D, J values must all be finite numbers.
+        """
+        import numpy as np
+        data = pd.DataFrame({
+            'open':   [10.0] * 20,
+            'high':   [10.0] * 20,
+            'low':    [10.0] * 20,
+            'close':  [10.0] * 20,
+            'volume': [1000] * 20,
+        })
+        stock = wrap(data)
+        kdjk = stock['kdjk']
+        kdjd = stock['kdjd']
+        kdjj = stock['kdjj']
+        for series, name in ((kdjk, 'kdjk'), (kdjd, 'kdjd'), (kdjj, 'kdjj')):
+            for i, val in enumerate(series.values):
+                assert_that(
+                    np.isfinite(val),
+                    equal_to(True),
+                    f"{name}[{i}] is not finite: {val}",
+                )
+
+    @staticmethod
+    def test_vr_neutral_days():
+        """Regression test for issue #115.
+
+        When all volume days are neutral (change == 0), both avs and bvs
+        are 0, so the VR formula should return 100.0
+        (half_cvs / half_cvs * 100 == 100) rather than 0 or NaN.
+        """
+        import numpy as np
+        data = pd.DataFrame({
+            'open':   [10.0] * 30,
+            'high':   [10.5] * 30,
+            'low':    [9.5]  * 30,
+            'close':  [10.0] * 30,   # no change => all neutral days
+            'volume': [1000] * 30,
+        })
+        stock = wrap(data)
+        vr = stock['vr']
+        for i, val in enumerate(vr.values):
+            assert_that(
+                np.isfinite(val),
+                equal_to(True),
+                f"vr[{i}] is not finite: {val}",
+            )
+            # all neutral: VR should be 100
+            assert_that(val, near_to(100.0))
 
     def test_column_cross(self):
         stock = self.get_stock_30days()


### PR DESCRIPTION
## Summary

This PR adds two regression tests that cover edge-case bugs reported by the community.

---

### Fix #185 — KDJ `ZeroDivisionError` on flat candles

**Root cause confirmed:** when `high == low` for every bar in the RSV rolling window, the denominator of the RSV formula is zero.  
The existing `_divide()` helper already guards against this by returning `0.0` where the divisor is zero — so no runtime crash occurs in modern code.  
However, there was **no test** covering this path, meaning a future refactor could silently regress.

**Added:** `test_kdj_flat_candles` — constructs a 20-row DataFrame where every bar is perfectly flat (`high == low == open == close == 10.0`) and asserts that `kdjk`, `kdjd`, and `kdjj` are all finite (no `NaN`, no `inf`, no exception).

---

### Fix #115 — VR Volume Ratio with neutral days

**Root cause confirmed:** per the VR specification, neutral days (where `change == 0`) contribute half their volume to both numerator and denominator:
```
VR = (avs + 0.5*cvs) / (bvs + 0.5*cvs) * 100
```
When all days are neutral, `avs == bvs == 0`, so the formula simplifies to `0.5*cvs / 0.5*cvs * 100 == 100`.  
The current implementation handles this correctly, but again had **no test** for the all-neutral case.

**Added:** `test_vr_neutral_days` — constructs a 30-row DataFrame with a constant close price (all neutral days) and asserts:
1. Every VR value is finite
2. Every VR value equals `100.0` (within tolerance)

---

### Files changed
- `test.py` — added `test_kdj_flat_candles` and `test_vr_neutral_days` (no changes to `stockstats.py`)

All existing tests pass unchanged.